### PR TITLE
Enables STATSD_HOST to be set to hostIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `metrics.serviceMonitor.enabled`   | Create ServiceMonitor object (`adminService.create` should be to `true`)        | `false`                           |
 | `metrics.serviceMonitor.interval`  | Interval at which metrics should be scraped                                     | `30s`                             |
 | `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                     | `30s`                             |
+| `metrics.sendStatsdToHostIP` | If true, enables statsd and sends metrics to hostIP                                   | `false`                             |
 
 **NOTE:** Make sure the configured `service.http.targetPort` and `service.https.targetPort` ports match your [Ambassador Module's](https://www.getambassador.io/reference/modules/#the-ambassador-module) `service_port` and `redirect_cleartext_from` configurations.
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -172,6 +172,14 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
               {{- end -}}
+            {{- if .Values.metrics.sendStatsdToHostIP }}
+            - name: STATSD_ENABLED
+              value: "true"
+            - name: STATSD_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- end }}
             {{- if .Values.env }}
             {{- range $key,$value := .Values.env }}
             - name: {{ $key | upper | quote}}


### PR DESCRIPTION
Couldn't figure out a way, using the helm chart as-is, to set STATSD_HOST to the lookup for hostIP. So, adding a specific helm chart value for that.